### PR TITLE
deps: Bump Spring Boot and project dependencies

### DIFF
--- a/boot-examples/pom.xml
+++ b/boot-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -15,10 +15,9 @@
     <description>boot-examples</description>
     <properties>
         <java.version>25</java.version>
-        <springdoc-openapi-starter-webmvc-ui.version>2.0.4</springdoc-openapi-starter-webmvc-ui.version>
+        <springdoc-openapi-starter-webmvc-ui.version>2.2.0</springdoc-openapi-starter-webmvc-ui.version>
         <openapi-generator-maven-plugin.version>7.0.1</openapi-generator-maven-plugin.version>
         <wiremock.version>3.13.2</wiremock.version>
-        <awaitility.version>4.2.1</awaitility.version>
         <instancio-junit.version>5.3.0</instancio-junit.version>
         <spring-boot-testjars.version>0.4.0.0-RC1</spring-boot-testjars.version>
     </properties>


### PR DESCRIPTION
- Upgrade Spring Boot parent from 4.0.0 to 4.0.3
- Update springdoc-openapi to 2.2.0
- Remove redundant awaitility version property
